### PR TITLE
Remove stray ]] in __fzy_cmd

### DIFF
--- a/fzy.plugin.zsh
+++ b/fzy.plugin.zsh
@@ -5,7 +5,7 @@ if [[ -n ${ZSH_FZY_TMUX} ]] ; then
 fi
 
 __fzy_cmd () {
-	[[ -n ${TMUX} ]] && "${ZSH_FZY_TMUX}" || fzy ]]
+	[[ -n ${TMUX} ]] && "${ZSH_FZY_TMUX}" || fzy
 }
 
 # CTRL-T: Place the selected file path in the command line


### PR DESCRIPTION
This has no corresponding `[[`. The earlier instance of `[[` to check for `${TMUX}` has already been closed. This causes `fzy` usage instructions to be output anywhere it is used by the plugin.

Looks like the issue was [introduced here](https://github.com/aperezdc/zsh-fzy/commit/ba4db9af6d49acd4c9e8a4246a393b4ee1f04d28#diff-89b9febd831c2e69c6cef3f90d267a08R6).