### PR TITLE
fzy should take the default value from the BUFFER

### DIFF
--- a/fzy.plugin.zsh
+++ b/fzy.plugin.zsh
@@ -5,7 +5,7 @@ if [[ -n ${ZSH_FZY_TMUX} ]] ; then
 fi
 
 __fzy_cmd () {
-	[[ -n ${TMUX} ]] && "${ZSH_FZY_TMUX}" || fzy
+	[[ -n ${TMUX} ]] && "${ZSH_FZY_TMUX}" || fzy -q "${BUFFER:-''}"
 }
 
 # CTRL-T: Place the selected file path in the command line


### PR DESCRIPTION
This ensures that the BUFFER (aka "the value currently in the shell before the bindkey is pressed") is used as the default search string.