### PR TITLE
Allow overrides for fzy flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# zsh-fzy
+
+zsh-fzy is a [zsh](http://www.zsh.org/) plugin that uses [fzy](https://github.com/jhawthorn/fzy) for 
+certain fuzzy matching operations.
+
+It can be installed manually, or by using a plugin manager, eg [zplug](https://github.com/zplug/zplug):
+
+```
+zplug "aperezdc/zsh-fzy"
+```
+
+## Configuration
+
+Flags for fzy can be set in your `~/.zshrc` thus:
+
+```
+ZSH_FZY_FLAGS=( -l 25 -s -j 4 )
+  
+# See fzy help for all available flags
+
+```

--- a/fzy.plugin.zsh
+++ b/fzy.plugin.zsh
@@ -1,5 +1,8 @@
 if [[ $- == *i* ]] ; then
 
+# Default fzy flags.
+declare -a ZSH_FZY_FLAGS=()
+
 command -v fzy >/dev/null
 if [[ $? -ne 0 ]]; then
     echo 'fzy is not installed. See https://github.com/jhawthorn/fzy'
@@ -11,7 +14,7 @@ if [[ -n ${ZSH_FZY_TMUX} ]] ; then
 fi
 
 __fzy_cmd () {
-	[[ -n ${TMUX} ]] && "${ZSH_FZY_TMUX}" || fzy -q "${BUFFER:-''}"
+	[[ -n ${TMUX} ]] && "${ZSH_FZY_TMUX}" || fzy -q "${BUFFER:-''}" "${ZSH_FZY_FLAGS[@]}"
 }
 
 # CTRL-T: Place the selected file path in the command line


### PR DESCRIPTION
This change adds the ability to supply flags to fzy by supplying a `ZSH_FZY_FLAGS` environment variable. It also supplies a README.

This is intentionally branched off https://github.com/aperezdc/zsh-fzy/pull/5 as it operates on the same line. I can rebase after that is merged.