### PR TITLE
Don't default to single quotes pair if nothing is in the buffer

### DIFF
--- a/fzy.plugin.zsh
+++ b/fzy.plugin.zsh
@@ -14,7 +14,7 @@ if [[ -n ${ZSH_FZY_TMUX} ]] ; then
 fi
 
 __fzy_cmd () {
-	[[ -n ${TMUX} ]] && "${ZSH_FZY_TMUX}" || fzy -q "${BUFFER:-''}" "${ZSH_FZY_FLAGS[@]}"
+	[[ -n ${TMUX} ]] && "${ZSH_FZY_TMUX}" || fzy -q "${BUFFER:-}" "${ZSH_FZY_FLAGS[@]}"
 }
 
 # CTRL-T: Place the selected file path in the command line


### PR DESCRIPTION
I've found that (now we've quoted it correctly!) opening the fzy finder with an empty BUFFER starts it with a pair of single quotes. This shouldn't happen.